### PR TITLE
fix fetch callback when answer is empty

### DIFF
--- a/src/adapter/index.js
+++ b/src/adapter/index.js
@@ -147,7 +147,7 @@ export default class Adapter {
         }
 
         if (HTTP_EMPTY_RESPONSE_STATUSES.includes(response.status)) {
-          return response.text()
+          return null;
         }
 
         return response.json();

--- a/src/adapter/index.js
+++ b/src/adapter/index.js
@@ -3,7 +3,10 @@ import { pluralize } from '../utils';
 
 const DEFAULT_CHUNK_SIZE = 20;
 const DEFAULT_CONTENT_TYPE = 'application/json; charset=utf-8';
-const HTTP_EMPTY_RESPONSE_STATUSES = [204];
+
+const HTTP_STATUS_NO_CONTENT = 204
+
+const HTTP_EMPTY_RESPONSE_STATUSES = [HTTP_STATUS_NO_CONTENT];
 
 export default class Adapter {
   constructor(container) {

--- a/src/adapter/index.js
+++ b/src/adapter/index.js
@@ -3,6 +3,7 @@ import { pluralize } from '../utils';
 
 const DEFAULT_CHUNK_SIZE = 20;
 const DEFAULT_CONTENT_TYPE = 'application/json; charset=utf-8';
+const HTTP_EMPTY_RESPONSE_STATUSES = [204];
 
 export default class Adapter {
   constructor(container) {
@@ -139,7 +140,11 @@ export default class Adapter {
         if (!response.ok) {
           const error = new Error(response.statusText);
           error.response = response;
-          throw error;          
+          throw error;
+        }
+
+        if (HTTP_EMPTY_RESPONSE_STATUSES.includes(response.status)) {
+          return response.text()
         }
 
         return response.json();


### PR DESCRIPTION
В случае удаления сущности может вернуться пустой ответ со статусом 204, что удивляет `response.json()` при попытке парсинга ответа